### PR TITLE
refs #1 長針の色を変更するオプションを追加した

### DIFF
--- a/src/main/java/com/github/clock/Args.java
+++ b/src/main/java/com/github/clock/Args.java
@@ -22,6 +22,13 @@ public class Args {
 
     @Option(name="-d", aliases="--debug", usage="debug mode.")
     private boolean debugMode = false;
+    
+    @Option(name="-lc", aliases="--long-hand-color", usage="長針の色を指定する。")
+     private String longHandColor = "#ff0000";
+
+     public String getLongHandColor(){
+         return longHandColor;
+     }
 
     public boolean isRunningMode(){
         return !isShowVersion() && !isShowHelp();


### PR DESCRIPTION
Argsに長針の色を変更するオプションを追加した.
ClockViewerがオブジェクトの色を受け取っていなかったため、受け取るように変更した.